### PR TITLE
ShEx Test extension: unescape string args per definition

### DIFF
--- a/jena-shex/src/main/java/org/apache/jena/shex/parser/ParserShExC.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/parser/ParserShExC.java
@@ -697,9 +697,14 @@ public class ParserShExC extends LangParserBase {
                 : iriAndCode.substring(codeDelimiter + 1, iriAndCode.length() - 2);
         }
 
-        SemAct ret = new SemAct(iri, code == null ? null : EscapeStr.unescapeUnicode(code));
+        SemAct ret = new SemAct(iri, code == null ? null : unescapeCode(code));
         stack("SemAct: %s %s", iri, code);
         return ret;
+    }
+
+    // CODE ::= "{" ([^%\] | '\' [%\] | UCHAR)* "%" "}" — decode UCHARs, then \% and \\
+    private static String unescapeCode(String code) {
+        return EscapeStr.unescapeUnicode(code).replaceAll("\\\\([%\\\\])", "$1");
     }
 
     // Metacharacters ., ?, *, +, {, } (, ), [ or ].

--- a/jena-shex/src/main/java/org/apache/jena/shex/semact/TestSemanticActionPlugin.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/semact/TestSemanticActionPlugin.java
@@ -41,7 +41,7 @@ public class TestSemanticActionPlugin implements SemanticActionPlugin {
     static Pattern ParsePattern, LeadPattern, LastPattern;
 
     static {
-        String term = "(\\\"(?:(?:[^\\\\\\\"]|\\\\[^\\\"])+)\\\"|[spo])";
+        String term = "(\\\"(?:[^\\\\\\\"]|\\\\\\\\|\\\\\\\")*\\\"|[spo])";
         ParsePattern = Pattern.compile("^ *(fail|print) *\\(((?:" + term + ", )*" + term + ")\\) *$");
         LeadPattern = Pattern.compile(term + ", ");
         LastPattern = Pattern.compile("((" + term + "))");
@@ -108,7 +108,12 @@ public class TestSemanticActionPlugin implements SemanticActionPlugin {
     }
 
     private static String getQuotedValue(String varName) {
-        return varName.substring(1, varName.length() - 1).replaceAll("\\\\(.)", "$1");
+        // strip the delimiters, then decode the two sanctioned escapes (\\ and \") in one pass
+        return varName.substring(1, varName.length() - 1).replaceAll("\\\\([\\\\\"])", "$1");
+    }
+
+    private static String nodeString(Node pos) {
+        return pos.isLiteral() ? pos.getLiteralLexicalForm() : pos.toString();
     }
 
     private static String resolveNodeVar(String varName, Node focus) {
@@ -121,7 +126,7 @@ public class TestSemanticActionPlugin implements SemanticActionPlugin {
             default:
                 throw new RuntimeException(String.format("ShapeExpr %s semantic action argument %s was not literal or 's'", SemActIri, varName));
         }
-        return pos.toString();
+        return nodeString(pos);
     }
 
     private static String resolveTripleVar(String varName, Triple triple) {
@@ -139,6 +144,6 @@ public class TestSemanticActionPlugin implements SemanticActionPlugin {
             default:
                 throw new RuntimeException(String.format("TripleExpr %s semantic action argument %s was not a literal or 's', 'p', or 'o'", SemActIri, varName));
         }
-        return pos.toString();
+        return nodeString(pos);
     }
 }

--- a/jena-shex/src/test/files/shexTest/validation/Is1_Ip1_L_with_backslash.ttl
+++ b/jena-shex/src/test/files/shexTest/validation/Is1_Ip1_L_with_backslash.ttl
@@ -1,0 +1,1 @@
+<http://a.example/s1> <http://a.example/p1> "a\\b" .

--- a/jena-shex/src/test/files/shexTest/validation/manifest.ttl
+++ b/jena-shex/src/test/files/shexTest/validation/manifest.ttl
@@ -1091,6 +1091,7 @@
         <#1dotNoCode3_pass>
         <#1dotCode3fail_abort>
         <#1dotCodeWithEscapes1_pass>
+        <#1dotCode1_with_backslash_pass>
         <#1dotShapeCode1_pass>
         <#1dotShapeNoCode1_pass>
         <#open3EachdotcloseCode1-p1p2p3>
@@ -14438,7 +14439,26 @@
     mf:extensionResults (
       [
         mf:extension <http://shex.io/extensions/Test/> ;
-        mf:prints "%{\\\\%}"
+        mf:prints "%{\\%}"
+      ]
+    )
+    .
+
+<#1dotCode1_with_backslash_pass> a sht:ValidationTest ;
+    mf:name "1dotCode1_with_backslash_pass" ;
+    sht:trait sht:SemanticAction ;
+    rdfs:comment "<S> { <p1> . %<Test>{ print(o) %} } on { <s1> <p1> 'a\\\\b' } — the object's value holds one backslash, calibrating that prints are unescaped literals" ;
+    mf:status mf:Approved ;
+    mf:action [
+      sht:schema <../schemas/1dotCode1.shex> ;
+      sht:shape <http://a.example/S1> ;
+      sht:data <Is1_Ip1_L_with_backslash.ttl> ;
+      sht:focus <http://a.example/s1>
+    ] ;
+    mf:extensionResults (
+      [
+        mf:extension <http://shex.io/extensions/Test/> ;
+        mf:prints "a\\b"
       ]
     )
     .


### PR DESCRIPTION
TestSemanticActionPlugin: adopt the definition's string grammar (escapes limited to \\ and \"), decode exactly those in getQuotedValue, and emit literal nodes' lexical forms. ParserShExC: decode ShExC CODE escapes (\% \\) after UCHARs so semantic-action code reaches plugins unescaped, per the CODE production.
Sync the shexTest snapshot's 1dotCodeWithEscapes1_pass expectation (%{\%}) and add 1dotCode1_with_backslash_pass + data file from shexTest@b152316.
TestShexValidation: 1122/0 failures; TS_Shex: 2144/0.

GitHub issue resolved #

Pull request Description:



----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
